### PR TITLE
Remove set_log_level from get_async_keyword to restore keyword functionality

### DIFF
--- a/runKeywordAsync/runKeywordAsync.py
+++ b/runKeywordAsync/runKeywordAsync.py
@@ -51,7 +51,7 @@ class runKeywordAsync:
             try:
               result = self._thread_pool[handle].result_queue.get(True, timeout)
               del self._thread_pool[handle]
-              BuiltIn().set_log_level(self._robot_log_level)
+              # BuiltIn().set_log_level(self._robot_log_level)
               return result
             except:
               raise Exception("Process " + str(handle) + " Failed")

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name = "robotframework-run-keyword-async",
-    version = "1.0.8",
+    version = "1.0.9",
     description = "Generic Robot Framework library for asynchronous keyword or method execution",
     author = "Awadh Shukla",
     author_email = "shukla.awadh@gmail.com",


### PR DESCRIPTION
Previous changes (disabled xml logger) break `get_async_return` keyword functionality as it could not find `self._robot_log_level` property.
Disabled `set_log_level` call to restore the keyword's functions.